### PR TITLE
Fix table export not working on CVE detail and Cluster detail pages

### DIFF
--- a/src/Components/SmartComponents/ClusterDetail/ClusterDetailTable.js
+++ b/src/Components/SmartComponents/ClusterDetail/ClusterDetailTable.js
@@ -46,11 +46,12 @@ const ClusterDetailTable = () => {
 
   const [cvss_score_min, cvss_score_max] = getCvssScoreFromUrlParam(cvss_score);
 
-  const onExport = useExport(
-    CLUSTER_DETAIL_EXPORT_PREFIX,
-    fetchClusterCves,
-    match.params.clusterId
-  );
+  const onExport = useExport({
+    filenamePrefix: CLUSTER_DETAIL_EXPORT_PREFIX,
+    fetchAction: fetchClusterCves,
+    fetchActionParam: match.params.clusterId,
+    allowedParams: CLUSTER_DETAIL_ALLOWED_PARAMS,
+  });
 
   const filters = [
     useTextFilter({

--- a/src/Components/SmartComponents/ClusterList/ClusterListTable.js
+++ b/src/Components/SmartComponents/ClusterList/ClusterListTable.js
@@ -48,7 +48,11 @@ const ClusterDetailTable = () => {
     dynamic_provider_options,
   } = meta;
 
-  const onExport = useExport(CLUSTER_LIST_EXPORT_PREFIX, fetchClusters);
+  const onExport = useExport({
+    filenamePrefix: CLUSTER_LIST_EXPORT_PREFIX,
+    fetchAction: fetchClusters,
+    allowedParams: CLUSTER_LIST_ALLOWED_PARAMS,
+  });
 
   const filters = [
     useTextFilter({

--- a/src/Components/SmartComponents/CveDetail/CveDetailTable.js
+++ b/src/Components/SmartComponents/CveDetail/CveDetailTable.js
@@ -49,11 +49,12 @@ const CveDetailTable = () => {
     dynamic_provider_options,
   } = meta;
 
-  const onExport = useExport(
-    CVE_DETAIL_EXPORT_PREFIX,
-    fetchExposedClusters,
-    match.params.cveId
-  );
+  const onExport = useExport({
+    filenamePrefix: CVE_DETAIL_EXPORT_PREFIX,
+    fetchAction: fetchExposedClusters,
+    fetchActionParam: match.params.cveId,
+    allowedParams: CVE_DETAIL_ALLOWED_PARAMS,
+  });
 
   const filters = [
     useTextFilter({

--- a/src/Components/SmartComponents/CveList/CveListTable.js
+++ b/src/Components/SmartComponents/CveList/CveListTable.js
@@ -43,7 +43,11 @@ const CveListTable = () => {
 
   const [cvss_score_min, cvss_score_max] = getCvssScoreFromUrlParam(cvss_score);
 
-  const onExport = useExport(CVE_LIST_EXPORT_PREFIX, fetchCves);
+  const onExport = useExport({
+    filenamePrefix: CVE_LIST_EXPORT_PREFIX,
+    fetchAction: fetchCves,
+    allowedParams: CVE_LIST_ALLOWED_PARAMS,
+  });
 
   const filters = [
     useTextFilter({

--- a/src/Helpers/hooks.js
+++ b/src/Helpers/hooks.js
@@ -175,7 +175,12 @@ export const useUrlBoundParams = ({
   return apply;
 };
 
-export const useExport = (filenamePrefix, fetchAction, fetchActionParam) => {
+export const useExport = ({
+  filenamePrefix,
+  fetchAction,
+  fetchActionParam,
+  allowedParams,
+}) => {
   const dispatch = useDispatch();
 
   const DEFAULT_PARAMS = {
@@ -194,9 +199,11 @@ export const useExport = (filenamePrefix, fetchAction, fetchActionParam) => {
     const formattedDate =
       new Date().toISOString().replace(/[T:]/g, '-').split('.')[0] + '-utc';
 
+    const filteredParams = filterParams(params, allowedParams);
+
     const payload = await fetchAction(
       {
-        ...transformUrlParamsBeforeFetching(params),
+        ...transformUrlParamsBeforeFetching(filteredParams),
         ...DEFAULT_PARAMS,
         data_format: format,
       },


### PR DESCRIPTION
Fixes [VULN4OS-184](https://issues.redhat.com/browse/VULN4OS-184).

Exporting on CVE detail and Cluster detail pages was not working due to some additional parameters being passed to API endpoints, wrapping URL params in `filterParams` function before passing them to API endpoint inside `useExport` hook fixes this issue by filtering out the problematic and unnecessary URL params.

How to test:
Try to export to JSON/CSV on all pages, you can also try applying some filters and check if they correctly affect the exported data.