### PR TITLE
chore: Pin loader-utils package version to fix a CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-cypress": "2.12.1",
         "identity-obj-proxy": "3.0.0",
         "jest": "28.1.1",
+        "loader-utils": "^2.0.3",
         "npm-run-all": "4.1.5",
         "prop-types": "15.8.1",
         "style-loader": "3.3.1",
@@ -15804,9 +15805,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -35227,9 +35228,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-cypress": "2.12.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "28.1.1",
+    "loader-utils": "^2.0.3",
     "npm-run-all": "4.1.5",
     "prop-types": "15.8.1",
     "style-loader": "3.3.1",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/VULN4OS-178.

CVE is fixed in version 2.0.3 https://github.com/webpack/loader-utils/issues/212