### PR TITLE
Fix service name missing in 403 empty state

### DIFF
--- a/src/Components/PresentationalComponents/ErrorHandler.js
+++ b/src/Components/PresentationalComponents/ErrorHandler.js
@@ -14,7 +14,7 @@ const ErrorHandler = ({ error, children }) => {
 
   switch (parsedCode) {
     case 403:
-      return <NotAuthorized />;
+      return <NotAuthorized serviceName="Vulnerability for OpenShift" />;
 
     case 404:
       return <InvalidObject />;


### PR DESCRIPTION
Fixes `undefined` in the title of this error state.

![Screenshot from 2023-02-01 18-16-56](https://user-images.githubusercontent.com/8426204/216116402-b04ba7bc-453b-4e42-9698-e8b350b2fb6e.png)
