### PR TITLE
chore: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "leSamo"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps):"
+    allow:
+      - dependency-name: "@redhat-cloud-services/frontend*"
+      - dependency-name: "@patternfly/*"
+        dependency-type: direct
+    ignore:
+      - dependency-name: "react-router-dom"
+        versions: ["6.x"]


### PR DESCRIPTION
This aligns the dependabot configuration to be consistent with Inventory, OCP Advisor, etc. Also it limits the scope of dependabot PRs to the FEC and PF modules only.