### PR TITLE
Add new tests for CVE list table

### DIFF
--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -142,3 +142,7 @@ export const itIsNotExpandable = () => {
     cy.get('thead [id^=expand-toggle]').should('not.exist');
   });
 };
+
+export const removeFilter = (chipText) => {
+  cy.get(`.pf-c-chip-group__main:contains(${chipText}) button`).click();
+};

--- a/src/Components/SmartComponents/CveList/CveListTable.cy.js
+++ b/src/Components/SmartComponents/CveList/CveListTable.cy.js
@@ -107,7 +107,7 @@ describe('CveListTable with items', () => {
     });
   });
 
-  describe.only('Filtering', () => {
+  describe('Filtering', () => {
     beforeEach(() => {
       cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
         ...initialState,

--- a/src/Components/SmartComponents/CveList/CveListTable.cy.js
+++ b/src/Components/SmartComponents/CveList/CveListTable.cy.js
@@ -6,7 +6,10 @@ import { Provider } from 'react-redux';
 import { init } from '../../../Store/ReducerRegistry';
 import cves from '../../../../cypress/fixtures/cvelist.json';
 import { initialState } from '../../../Store/Reducers/CveListStore';
-import { CVE_LIST_EXPORT_PREFIX } from '../../../Helpers/constants';
+import {
+  CVE_LIST_EXPORT_PREFIX,
+  PUBLISHED_OPTIONS,
+} from '../../../Helpers/constants';
 import {
   itIsExpandable,
   itIsSortedBy,
@@ -14,8 +17,9 @@ import {
   itHasActiveFilter,
   itIsNotSorted,
   itHasTableFunctionsDisabled,
+  removeFilter,
 } from '../../../../cypress/utils/table';
-import _ from 'lodash';
+import { CVE_LIST_TABLE_COLUMNS } from '../../../Helpers/constants';
 
 const mountComponent = () => {
   mount(
@@ -66,54 +70,16 @@ describe('CveListTable with items', () => {
     cy.contains('No description available');
   });
 
-  describe('CveListTable without items', () => {
-    beforeEach(() => {
-      cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
-        ...initialState,
-        data: [],
-        meta: {
-          ...initialState.meta,
-          total_items: 0,
-        },
-      });
-
-      mountComponent();
-    });
-
-    it('exists and matches screenshot', () => {
-      cy.get('table');
-
-      cy.get('body').matchImage();
-    });
-
-    it('has no items', () => {
-      cy.get('[data-label="CVE ID"]').should('have.length', 0);
-    });
-
-    itIsNotSorted();
-    itHasTableFunctionsDisabled();
-
-    it('shows correct empty state depending on whether filters are applied or not', () => {
-      cy.contains('No matching CVEs found').should('exist');
-
-      cy.get('.ins-c-chip-filters .pf-c-chip button').click();
-
-      cy.contains('No matching CVEs found').should('exist');
-      cy.contains('Reset filter').should('exist');
-    });
-  });
-
-  describe.only('Sorting CveListTable with items', () => {
+  describe('Sorting', () => {
     beforeEach(() => {
       cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
         ...initialState,
         ...cves,
         meta: {
-          sort: null,
           ...initialState.meta,
           ...cves.meta,
         },
-      }).as('call');
+      });
 
       mountComponent();
     });
@@ -127,26 +93,101 @@ describe('CveListTable with items', () => {
       cy.get(tableHeaders).children().eq(index).click();
       cy.url().should('include', `sort=${sortingParameter}`);
     };
-    _.zip(
-      [
-        'synopsis',
-        'publish_date',
-        'severity',
-        'cvss_score',
-        'clusters_exposed',
-      ],
-      [
-        'CVE ID',
-        'Publish date',
-        'Severity',
-        'CVSS base score',
-        'Exposed clusters',
-      ]
-    ).forEach(([category, label], index) => {
+
+    CVE_LIST_TABLE_COLUMNS.map((column) => [
+      column.sortParam,
+      column.title,
+    ]).forEach(([category, label], index) => {
       let sortingParameter = category;
-      it(`Sorted by ${label}`, () => {
+      it(`is sorted by ${label}`, () => {
         checkSortingUrl(sortingParameter, index + 1);
       });
     });
+  });
+
+  describe('Filtering', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
+        ...initialState,
+        ...cves,
+        meta: {
+          ...initialState.meta,
+          ...cves.meta,
+        },
+      });
+
+      mountComponent();
+    });
+
+    const filters = [
+      {
+        urlParam: 'search',
+        type: 'text',
+        selector: '#text-filter-search',
+        chipText: 'Search term',
+      },
+      {
+        urlParam: 'published',
+        type: 'radio',
+        selector: '.ins-c-conditional-filter .pf-m-fill button',
+        items: PUBLISHED_OPTIONS,
+      },
+    ];
+
+    filters.forEach((filter, index) => {
+      it(`filters by ${filter.urlParam}`, () => {
+        cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
+        cy.get('.pf-c-dropdown__menu').children().eq(index).click();
+
+        switch (filter.type) {
+          case 'text': {
+            cy.get(filter.selector).type('test');
+            cy.url().should('include', `${filter.urlParam}=test`);
+            cy.contains('Reset filter');
+            itHasActiveFilter(filter.chipText, 'test');
+
+            removeFilter(filter.chipText);
+            cy.url().should('not.include', `${filter.urlParam}=test`);
+          }
+        }
+      });
+    });
+  });
+});
+
+describe('CveListTable without items', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
+      ...initialState,
+      data: [],
+      meta: {
+        ...initialState.meta,
+        total_items: 0,
+      },
+    });
+
+    mountComponent();
+  });
+
+  it('exists and matches screenshot', () => {
+    cy.get('table');
+
+    cy.get('body').matchImage();
+  });
+
+  it('has no items', () => {
+    cy.get('[data-label="CVE ID"]').should('have.length', 0);
+  });
+
+  itIsNotSorted();
+  itHasTableFunctionsDisabled();
+
+  it('shows correct empty state depending on whether filters are applied or not', () => {
+    cy.contains('No matching CVEs found').should('exist');
+
+    cy.get('.ins-c-chip-filters .pf-c-chip button').click();
+
+    cy.contains('No matching CVEs found').should('exist');
+    cy.contains('Reset filter').should('exist');
   });
 });

--- a/src/Components/SmartComponents/CveList/CveListTable.cy.js
+++ b/src/Components/SmartComponents/CveList/CveListTable.cy.js
@@ -8,7 +8,9 @@ import cves from '../../../../cypress/fixtures/cvelist.json';
 import { initialState } from '../../../Store/Reducers/CveListStore';
 import {
   CVE_LIST_EXPORT_PREFIX,
+  EXPOSED_CLUSTERS_OPTIONS,
   PUBLISHED_OPTIONS,
+  SEVERITY_OPTIONS,
 } from '../../../Helpers/constants';
 import {
   itIsExpandable,
@@ -105,7 +107,7 @@ describe('CveListTable with items', () => {
     });
   });
 
-  describe('Filtering', () => {
+  describe.only('Filtering', () => {
     beforeEach(() => {
       cy.intercept('GET', '**/api/ocp-vulnerability/v1/cves**', {
         ...initialState,
@@ -123,7 +125,7 @@ describe('CveListTable with items', () => {
       {
         urlParam: 'search',
         type: 'text',
-        selector: '#text-filter-search',
+        selector: '.ins-c-conditional-filter input[type="text"]',
         chipText: 'Search term',
       },
       {
@@ -131,9 +133,32 @@ describe('CveListTable with items', () => {
         type: 'radio',
         selector: '.ins-c-conditional-filter .pf-m-fill button',
         items: PUBLISHED_OPTIONS,
+        chipText: 'Publish date',
+      },
+      {
+        urlParam: 'severity',
+        type: 'checkbox',
+        selector: '.ins-c-conditional-filter .pf-m-fill button',
+        items: SEVERITY_OPTIONS,
+        chipText: 'Severity',
+      },
+      {
+        urlParam: 'cvss_score',
+        type: 'range',
+        selector: '.ins-c-conditional-filter .pf-m-fill button',
+        chipText: 'CVSS base score',
+      },
+      {
+        urlParam: 'affected_clusters',
+        type: 'checkbox',
+        selector: '.ins-c-conditional-filter .pf-m-fill button',
+        items: EXPOSED_CLUSTERS_OPTIONS,
+        chipText: 'Exposed clusters',
+        activeByDefault: true,
       },
     ];
 
+    // TODO: Refactor this into a utility function
     filters.forEach((filter, index) => {
       it(`filters by ${filter.urlParam}`, () => {
         cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
@@ -147,7 +172,118 @@ describe('CveListTable with items', () => {
             itHasActiveFilter(filter.chipText, 'test');
 
             removeFilter(filter.chipText);
-            cy.url().should('not.include', `${filter.urlParam}=test`);
+            cy.url().should('not.include', `${filter.urlParam}`);
+
+            break;
+          }
+
+          case 'radio': {
+            cy.get(filter.selector).click();
+
+            cy.get('.pf-c-select__menu')
+              .children()
+              .each((child, index) => {
+                if (index === 0) {
+                  cy.contains('Reset filter').should('not.exist');
+                } else {
+                  const option = filter.items[index];
+
+                  cy.get(child).click();
+
+                  cy.url().should(
+                    'include',
+                    `${filter.urlParam}=${option.value}`
+                  );
+
+                  cy.contains('Reset filter');
+                  itHasActiveFilter(filter.chipText, option.label);
+                }
+              });
+
+            // close the dropdown so it does not obstruct remove chip button
+            cy.get(filter.selector).eq(0).click();
+            removeFilter(filter.chipText);
+            cy.url().should('not.include', `${filter.urlParam}`);
+
+            break;
+          }
+
+          case 'checkbox': {
+            cy.get(filter.selector).click();
+
+            // uncheck all possible values selected by default
+            if (filter.activeByDefault) {
+              cy.get('.pf-c-select__menu input[type="checkbox"]').uncheck({
+                multiple: true,
+              });
+            }
+
+            let selectedValues = [];
+
+            cy.get('.pf-c-select__menu')
+              .children()
+              .each((child, index) => {
+                const option = filter.items[index];
+
+                cy.get(child).click();
+
+                selectedValues.push(option.value);
+
+                cy.url().should(
+                  'include',
+                  `${filter.urlParam}=${encodeURIComponent(
+                    selectedValues.join(',')
+                  )}`
+                );
+
+                if (!filter.activeByDefault) {
+                  cy.contains('Reset filter');
+                }
+                itHasActiveFilter(filter.chipText, option.label);
+              });
+
+            // close the dropdown so it does not obstruct remove chip button
+            cy.get(filter.selector).eq(0).click();
+            cy.contains('Reset filter').click();
+
+            if (!filter.activeByDefault) {
+              cy.url().should('not.include', `${filter.urlParam}`);
+            }
+
+            break;
+          }
+
+          case 'range': {
+            cy.get(filter.selector).click();
+
+            cy.get('#range-filter-input-min').clear();
+            cy.get('#range-filter-input-min').type('1');
+
+            cy.get('#range-filter-input-max').clear();
+            cy.get('#range-filter-input-max').type('9.555');
+
+            cy.contains('Reset filter');
+            itHasActiveFilter(filter.chipText, '1.0 - 9.5');
+            cy.url().should(
+              'include',
+              `${filter.urlParam}=${encodeURIComponent('1,9.5')}`
+            );
+
+            // if value is out of range, the filter should not get applied
+            cy.get('#range-filter-input-min').clear();
+            cy.get('#range-filter-input-min').type('-1');
+
+            cy.get('#range-filter-input-min[aria-invalid="true"]');
+
+            itHasActiveFilter(filter.chipText, '1,9.5');
+
+            // if min > max, the filter should not get applied
+            cy.get('#range-filter-input-max').clear();
+            cy.get('#range-filter-input-max').type('0.5');
+
+            itHasActiveFilter(filter.chipText, '1,9.5');
+
+            break;
           }
         }
       });


### PR DESCRIPTION
- Fix most CVE list table tests not running due to forgotten `only` cypress method.
- Programmatically generate columns in tests from constants instead of hardcoding them in tests.
- Add tests for all filters on CVE list page.

I'll like to isolate filter tests in helper file and use the logic in other pages in a future PR. 