### PR TITLE
Reset offset on table reload

### DIFF
--- a/src/Helpers/hooks.js
+++ b/src/Helpers/hooks.js
@@ -145,7 +145,7 @@ export const useUrlBoundParams = ({
   useEffect(() => {
     const initialUrlParams = getUrlParams();
 
-    apply({ ...initialParams, ...initialUrlParams });
+    apply({ ...initialParams, ...initialUrlParams, offset: 0 });
     setFirstLoad(false);
   }, []);
 


### PR DESCRIPTION
### The problem:
Table parameters are remembered when you change pages which is correct but remembering offset (currently selected page) could mean you receive out of bounds page, for example:
1. Go to CVE list page
2. Open a CVE with 1000 exposed clusters -- go to page 2
3. Go back to CVE list page
4. Open a CVE with 10 exposed clusters -- the table would remember being on page 2 and would show empty table, even though it should be on page 1 and showing 10 clusters.

### The fix:
Always set the offset to 0 (page to 1) on table load.