### PR TITLE
Use up to date Skeleton and SkeletonTable components

### DIFF
--- a/src/Components/PresentationalComponents/WithLoader.js
+++ b/src/Components/PresentationalComponents/WithLoader.js
@@ -1,13 +1,9 @@
-import {
-  Skeleton,
-  SkeletonSize,
-} from '@redhat-cloud-services/frontend-components/Skeleton';
-import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable/SkeletonTable';
 import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import propTypes from 'prop-types';
 import React from 'react';
 import { TableVariant } from '@patternfly/react-table';
-import { Skeleton as PfSkeleton } from '@patternfly/react-core';
+import { Skeleton } from '@patternfly/react-core';
+import { SkeletonTable } from '@patternfly/react-component-groups';
 
 export const LoaderType = {
   spinner: 'spinner',
@@ -31,14 +27,14 @@ const WithLoader = ({ isLoading, variant, children, size, ...props }) => {
         return <Skeleton shape="square" {...props} />;
       case LoaderType.inlineSkeleton:
         return (
-          <PfSkeleton
-            size={size ?? SkeletonSize.lg}
+          <Skeleton
+            fontSize="sm"
             {...props}
             style={{ display: 'inline-block', ...props.style }}
           />
         );
       default:
-        return <Skeleton size={size ?? SkeletonSize.lg} {...props} />;
+        return <Skeleton fontSize="sm" {...props} />;
     }
   }
 

--- a/src/Components/SmartComponents/ClusterDetail/ClusterDetailPageHeader.js
+++ b/src/Components/SmartComponents/ClusterDetail/ClusterDetailPageHeader.js
@@ -49,7 +49,6 @@ const ClusterDetailPageHeader = () => {
           <WithLoader
             variant={LoaderType.inlineSkeleton}
             width="200px"
-            fontSize="sm"
             isLoading={isDetailLoading}
             style={{ verticalAlign: -4 }}
           >
@@ -63,7 +62,6 @@ const ClusterDetailPageHeader = () => {
         <WithLoader
           variant={LoaderType.inlineSkeleton}
           width="300px"
-          fontSize="sm"
           isLoading={isDetailLoading}
           style={{ verticalAlign: -4 }}
         >
@@ -77,7 +75,6 @@ const ClusterDetailPageHeader = () => {
         <WithLoader
           variant={LoaderType.inlineSkeleton}
           width="200px"
-          fontSize="sm"
           isLoading={isDetailLoading}
           style={{ verticalAlign: -4 }}
         >

--- a/src/Components/SmartComponents/CveDetail/CveDetailPageHeader.js
+++ b/src/Components/SmartComponents/CveDetail/CveDetailPageHeader.js
@@ -87,7 +87,6 @@ const CveDetailPageHeader = () => {
                   isLoading={isDetailLoading}
                   variant={LoaderType.inlineSkeleton}
                   width="100px"
-                  fontSize="sm"
                   style={{ verticalAlign: -4 }}
                 >
                   <span data-ouia-component-id="cve-detail-publish-date">
@@ -144,7 +143,6 @@ const CveDetailPageHeader = () => {
                 isLoading={isDetailLoading}
                 variant={LoaderType.inlineSkeleton}
                 width="100px"
-                fontSize="sm"
                 style={{ verticalAlign: -4 }}
               >
                 <b>

--- a/src/Components/SmartComponents/Table/BaseTableBody.js
+++ b/src/Components/SmartComponents/Table/BaseTableBody.js
@@ -10,9 +10,9 @@ import {
   ExpandableRowContent,
   SortByDirection,
 } from '@patternfly/react-table';
-import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable/SkeletonTable';
 import { TableVariant } from '@patternfly/react-table';
 import { DEFAULT_LIMIT } from '../../../Helpers/constants';
+import { SkeletonTable } from '@patternfly/react-component-groups';
 
 const BaseTableBody = ({
   isLoading,


### PR DESCRIPTION
The components from FEC are deprecated and should be replaced by components from PatternFly.
