### PR TITLE
fix: Rename Vulnerability titles to Vulnerability Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "cypress": "^13.13.3",
         "eslint": "^8.57.0",
         "eslint-plugin-cypress": "^2.15.1",
-        "eslint-plugin-no-only-tests": "^3.1.0",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "npm-run-all": "4.1.5",
         "strict-uri-encode": "^2.0.0",
         "stylelint": "^16.3.1",
@@ -7602,9 +7602,9 @@
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
-      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
       "dev": true,
       "engines": {
         "node": ">=5.0.0"
@@ -23248,9 +23248,9 @@
       }
     },
     "eslint-plugin-no-only-tests": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
-      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
       "dev": true
     },
     "eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "cypress": "^13.13.3",
     "eslint": "^8.57.0",
     "eslint-plugin-cypress": "^2.15.1",
-    "eslint-plugin-no-only-tests": "^3.1.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "npm-run-all": "4.1.5",
     "strict-uri-encode": "^2.0.0",
     "stylelint": "^16.3.1",

--- a/src/Components/SmartComponents/ClusterDetail/ClusterDetailPage.js
+++ b/src/Components/SmartComponents/ClusterDetail/ClusterDetailPage.js
@@ -19,7 +19,7 @@ const ClusterDetailPage = ({ activeTab }) => {
   useEffect(() => {
     cluster.display_name &&
       chrome.updateDocumentTitle(
-        `${cluster.display_name} - Clusters - Vulnerability | OpenShift`
+        `${cluster.display_name} - Clusters - Vulnerability Dashboard | OpenShift`
       );
   }, [cluster.display_name]);
 

--- a/src/Components/SmartComponents/ClusterList/ClusterListPage.js
+++ b/src/Components/SmartComponents/ClusterList/ClusterListPage.js
@@ -21,7 +21,7 @@ const ClusterListPage = () => {
   );
 
   useEffect(() => {
-    chrome.updateDocumentTitle('Clusters - Vulnerability | OpenShift');
+    chrome.updateDocumentTitle('Clusters - Vulnerability Dashboard | OpenShift');
   }, []);
 
   return (

--- a/src/Components/SmartComponents/ClusterList/ClusterListPage.js
+++ b/src/Components/SmartComponents/ClusterList/ClusterListPage.js
@@ -21,7 +21,9 @@ const ClusterListPage = () => {
   );
 
   useEffect(() => {
-    chrome.updateDocumentTitle('Clusters - Vulnerability Dashboard | OpenShift');
+    chrome.updateDocumentTitle(
+      'Clusters - Vulnerability Dashboard | OpenShift'
+    );
   }, []);
 
   return (

--- a/src/Components/SmartComponents/CveDetail/CveDetailPage.js
+++ b/src/Components/SmartComponents/CveDetail/CveDetailPage.js
@@ -17,7 +17,7 @@ const CveDetailPage = ({ activeTab }) => {
   useEffect(() => {
     cve.synopsis &&
       chrome.updateDocumentTitle(
-        `${cve.synopsis} - CVEs - Vulnerability | OpenShift`
+        `${cve.synopsis} - CVEs - Vulnerability Dashboard | OpenShift`
       );
   }, [cve.synopsis]);
 

--- a/src/Components/SmartComponents/CveList/CveListPage.js
+++ b/src/Components/SmartComponents/CveList/CveListPage.js
@@ -30,7 +30,7 @@ const CveListPage = () => {
   );
 
   useEffect(() => {
-    chrome.updateDocumentTitle('CVEs - Vulnerability | OpenShift');
+    chrome.updateDocumentTitle('CVEs - Vulnerability Dashboard | OpenShift');
   }, []);
 
   const HeaderTitle = (


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-9388.

This is a quick PR to address the incorrect title we used with the recent changes: vuln4shift is officially called "Vulnerability Dashboard".