### PR TITLE
feat: Lightspeed rebranding

### DIFF
--- a/src/Components/PresentationalComponents/EmptyStates/MissingMetadata.js
+++ b/src/Components/PresentationalComponents/EmptyStates/MissingMetadata.js
@@ -6,21 +6,28 @@ import {
   Bullseye,
   Text,
 } from '@patternfly/react-core';
+import { useFeatureFlag } from '../../../Helpers/hooks';
 
-const MissingMetadata = ({ ...props }) => (
-  <Bullseye>
-    <EmptyState variant="lg" {...props}>
-      <Text>
-        <strong>No description available</strong>
-      </Text>
-      <EmptyStateBody>
-        This CVE has been published, however metadata about this CVE is not yet
-        available on Red Hat Insights. Metadata is usually available on Insights
-        within 24 hours of a CVE being published.
-      </EmptyStateBody>
-    </EmptyState>
-  </Bullseye>
-);
+const MissingMetadata = ({ ...props }) => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+
+  return (
+    <Bullseye>
+      <EmptyState variant="lg" {...props}>
+        <Text>
+          <strong>No description available</strong>
+        </Text>
+        <EmptyStateBody>
+          This CVE has been published, however metadata about this CVE is not
+          yet available on Red Hat{' '}
+          {isLightspeedEnabled ? 'Lightspeed' : 'Insights'}. Metadata is usually
+          available on {isLightspeedEnabled ? 'Lightspeed' : 'Insights'} within
+          24 hours of a CVE being published.
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  );
+};
 
 MissingMetadata.propTypes = {
   props: propTypes.object,

--- a/src/Components/PresentationalComponents/EmptyStates/NoClusters.js
+++ b/src/Components/PresentationalComponents/EmptyStates/NoClusters.js
@@ -9,41 +9,46 @@ import {
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useFeatureFlag } from '../../../Helpers/hooks';
 
-const NoClusters = () => (
-  <Bullseye>
-    <EmptyState variant="lg">
-      <EmptyStateHeader
-        titleText="No clusters yet"
-        icon={<EmptyStateIcon icon={PlusCircleIcon} size="sm" />}
-        headingLevel="h5"
-      />
-      <EmptyStateBody>
-        To get started, create or register your cluster to get information from
-        Insights Vulnerability.
-      </EmptyStateBody>
-      <EmptyStateFooter>
-        <Button
-          variant="primary"
-          component="a"
-          href="https://console.redhat.com/openshift/create/"
-          target="_blank"
-        >
-          Create Cluster
-        </Button>
-        <br />
-        <Button
-          variant="link"
-          component="a"
-          href="https://console.redhat.com/openshift/register/"
-          target="_blank"
-          className="pf-v5-u-mt-md"
-        >
-          Register Cluster
-        </Button>
-      </EmptyStateFooter>
-    </EmptyState>
-  </Bullseye>
-);
+const NoClusters = () => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+
+  return (
+    <Bullseye>
+      <EmptyState variant="lg">
+        <EmptyStateHeader
+          titleText="No clusters yet"
+          icon={<EmptyStateIcon icon={PlusCircleIcon} size="sm" />}
+          headingLevel="h5"
+        />
+        <EmptyStateBody>
+          To get started, create or register your cluster to get information
+          from {isLightspeedEnabled ? 'Lightspeed' : 'Insights'} Vulnerability.
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <Button
+            variant="primary"
+            component="a"
+            href="https://console.redhat.com/openshift/create/"
+            target="_blank"
+          >
+            Create Cluster
+          </Button>
+          <br />
+          <Button
+            variant="link"
+            component="a"
+            href="https://console.redhat.com/openshift/register/"
+            target="_blank"
+            className="pf-v5-u-mt-md"
+          >
+            Register Cluster
+          </Button>
+        </EmptyStateFooter>
+      </EmptyState>
+    </Bullseye>
+  );
+};
 
 export default NoClusters;

--- a/src/Components/PresentationalComponents/EmptyStates/NoMatchingCves.js
+++ b/src/Components/PresentationalComponents/EmptyStates/NoMatchingCves.js
@@ -6,8 +6,11 @@ import {
   EmptyStateHeader,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useFeatureFlag } from '../../../Helpers/hooks';
 
 const NoMatchingCves = () => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+
   const CveDatabaseLink = (
     <a
       href="https://access.redhat.com/security/security-updates/#/cve"
@@ -41,10 +44,11 @@ const NoMatchingCves = () => {
           To continue, edit your filter settings and search again.
           <br />
           <br />
-          As of today, Insights Vulnerability shows CVEs with Errata. It is
-          possible the CVE you are searching for does not yet have an associated
-          Errata. Please check the {CveDatabaseLink} or if you would like more
-          information, contact {ProdSecLink}
+          As of today, {isLightspeedEnabled ? 'Lightspeed' : 'Insights'}{' '}
+          Vulnerability shows CVEs with Errata. It is possible the CVE you are
+          searching for does not yet have an associated Errata. Please check the{' '}
+          {CveDatabaseLink} or if you would like more information, contact{' '}
+          {ProdSecLink}
         </EmptyStateBody>
       </EmptyState>
     </Bullseye>

--- a/src/Components/PresentationalComponents/WithLoader.js
+++ b/src/Components/PresentationalComponents/WithLoader.js
@@ -14,7 +14,7 @@ export const LoaderType = {
   skeleton: 'skeleton',
 };
 
-const WithLoader = ({ isLoading, variant, children, size, ...props }) => {
+const WithLoader = ({ isLoading, variant, children, ...props }) => {
   if (isLoading) {
     switch (variant) {
       case LoaderType.spinner:
@@ -46,7 +46,6 @@ WithLoader.propTypes = {
   variant: propTypes.oneOf(Object.keys(LoaderType)),
   style: propTypes.object,
   children: propTypes.node,
-  size: propTypes.string,
 };
 
 export default WithLoader;

--- a/src/Components/SmartComponents/CveList/CveListPage.js
+++ b/src/Components/SmartComponents/CveList/CveListPage.js
@@ -15,12 +15,13 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import CveListTable from './CveListTable';
-import { useLocalStorage } from '../../../Helpers/hooks';
+import { useFeatureFlag, useLocalStorage } from '../../../Helpers/hooks';
 import { HEADER_ALERT_DISMISSED_KEY } from '../../../Helpers/constants';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const CveListPage = () => {
   const chrome = useChrome();
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
 
   const PRODUCT_DOC =
     'https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest';
@@ -42,8 +43,9 @@ const CveListPage = () => {
       bodyContent={
         <Fragment>
           The Vulnerability service identifies CVEs with errata that may affect
-          your Insights-connected OpenShift clusters. Vulnerability information
-          applies for OCP4.8+ version only.
+          your {isLightspeedEnabled ? 'Lightspeed' : 'Insights'}-connected
+          OpenShift clusters. Vulnerability information applies for OCP4.8+
+          version only.
         </Fragment>
       }
       footerContent={


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-19796

## Summary by Sourcery

Introduce a feature flag to toggle UI branding from Insights to Lightspeed across multiple components and clean up an unused prop.

New Features:
- Add platform.lightspeed-rebrand feature flag to control product naming in the UI.

Enhancements:
- Update empty state and page components to display 'Lightspeed' or 'Insights' based on the feature flag.
- Remove the unused size prop and its propType from the WithLoader component.