### PR TITLE
chore: add analytics API keys to frontend deploy config

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -78,7 +78,14 @@ objects:
             - Errat
 
       module:
+        analytics:
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
         manifestLocation: "/apps/ocp-vulnerability/fed-mods.json"
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Vulnerability for OpenShift
         modules:
           - id: "ocp-vulnerability"
             module: "./RootApp"


### PR DESCRIPTION
## Summary
- Adds the `analytics` block with `APIKey` and `APIKeyDev` to the `module` section in `deploy/frontend.yml`
- Aligns with the pattern used by other frontends (inventory, advisor, tasks, ocp-advisor)

## Test plan
- [ ] Verify the YAML is valid and the deploy CRD parses correctly
- [ ] Confirm analytics events are sent in stage with the correct API key

## Summary by Sourcery

Deployment:
- Configure analytics APIKey and APIKeyDev in the frontend deployment YAML for the ocp-vulnerability module.