### PR TITLE
fix(CI): add codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,10 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npm run ci:verify
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage-final.json,./coverage-cypress/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: npm run build

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
     ],
   ],
   env: {
-    component: {
+    componentTest: {
       plugins: ['istanbul'],
     },
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "npm run test:ct",
     "test:coverage": "curl -sSL 'https://raw.githubusercontent.com/RedHatInsights/insights-interact-tools/refs/heads/main/scripts/coverage.sh' | bash",
     "test:ct": "BABEL_ENV=componentTest cypress run --component",
-    "test:openct": "BABEL_ENV=component cypress open --component",
+    "test:openct": "BABEL_ENV=componentTest cypress open --component",
     "ci:verify": "npm run test:coverage",
     "verify": "npm-run-all build lint test",
     "postinstall": "ts-patch install"


### PR DESCRIPTION
ci:verify script was taking care of uploading coverage before, but it got broken because of outdated codecov cli. To avoid such issues in the future, we better use upload codecov action which is supported

## Summary by Sourcery

CI:
- Upload multiple coverage report files to Codecov using the maintained GitHub Action instead of the previous script-based approach.